### PR TITLE
CIR-2388 Update tests due to `decisionData.decision` enumeration changes in the API (version 2)

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
@@ -46,7 +46,7 @@ class OutcomeAuditingV2Spec extends BaseSpec with OutcomeAuditV2 with WireMockTr
                 s"&& @.detail.correlationData.correlationIdType == 'ACKNOWLEDGEMENT_ID'" +
                 s"&& @.detail.submitter == 'sa-reg'" +
                 s"&& @.detail.decisionData[0].businessEvent == 'SARegistrationSubmitted'" +
-                s"&& @.detail.decisionData[0].decision == 'ACCEPTED'" +
+                s"&& @.detail.decisionData[0].decision == 'ACCEPT'" +
                 s"&& @.detail.decisionData[0].evidence[0].decisionMethod == 'AUTOMATIC'" +
                 s"&& @.detail.decisionData[0].evidence[0].decisionSystem == 'sa-reg'" +
                 s"&& @.detail.decisionData[0].evidence[0].decisionTimestamp == '2025-07-09T08:14:13Z'" +

--- a/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
@@ -29,7 +29,7 @@ trait OutcomeAuditV2 {
       |  "decisionData": [
       |    {
       |      "businessEvent": "SARegistrationSubmitted",
-      |      "decision": "ACCEPTED",
+      |      "decision": "ACCEPT",
       |      "reasons": [
       |        "LOW_RISK_SCORE"
       |      ],
@@ -64,7 +64,7 @@ trait OutcomeAuditV2 {
       |  "decisionData": [
       |    {
       |      "businessEvent": "SARegistrationSubmitted",
-      |      "decision": "ACCEPTED",
+      |      "decision": "ACCEPT",
       |      "reasons": [
       |        "LOW_RISK_SCORE"
       |      ],


### PR DESCRIPTION
This pull request updates the expected value for the `decision` field from `"ACCEPTED"` to `"ACCEPT"` in both the test data and test assertions to align with the latest specification for outcome auditing. This ensures consistency between the test expectations and the actual system behavior.

**Test data and assertion updates:**

* Updated the expected `decision` value from `"ACCEPTED"` to `"ACCEPT"` in the JSON test data within `OutcomeAuditV2.scala`. [[1]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL32-R32) [[2]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL67-R67)
* Changed the assertion in `OutcomeAuditingV2Spec.scala` to check for `"ACCEPT"` instead of `"ACCEPTED"` when verifying the outcome audit details.