### PR TITLE
CIR-2487 Update to change correlationData to be an array

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
@@ -42,8 +42,10 @@ class OutcomeAuditingV2Spec extends BaseSpec with OutcomeAuditV2 with WireMockTr
               "$[?(" +
                 s"@.auditSource == '${TestConfiguration.expectedServiceName}'" +
                 s"&& @.auditType == 'OutcomeReportingSubmitted'" +
-                s"&& @.detail.correlationData.correlationId == '33df37a4-a535-41fe-8032-7ab718b45526'" +
-                s"&& @.detail.correlationData.correlationIdType == 'ACKNOWLEDGEMENT_ID'" +
+                s"&& @.detail.correlationData[0].correlationId == '33df37a4-a535-41fe-8032-7ab718b45526'" +
+                s"&& @.detail.correlationData[0].correlationIdType == 'SUBMISSION_ID'" +
+                s"&& @.detail.correlationData[1].correlationId == '22bbf4e1-5f4c-4d2e-9c8b-1f4e6e8c9a12'" +
+                s"&& @.detail.correlationData[1].correlationIdType == 'SESSION_ID'" +
                 s"&& @.detail.submitter == 'sa-reg'" +
                 s"&& @.detail.decisionData[0].businessEvent == 'SARegistrationSubmitted'" +
                 s"&& @.detail.decisionData[0].decision == 'ACCEPT'" +

--- a/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
@@ -21,10 +21,16 @@ import play.api.libs.json.{JsValue, Json}
 trait OutcomeAuditV2 {
   val validOutcomeAuditingV2Json: JsValue = Json.parse(
     """{
-      |  "correlationData": {
-      |    "correlationId": "33df37a4-a535-41fe-8032-7ab718b45526",
-      |    "correlationIdType": "ACKNOWLEDGEMENT_ID"
-      |  },
+      |  "correlationData": [
+      |     {
+      |       "correlationId": "33df37a4-a535-41fe-8032-7ab718b45526",
+      |       "correlationIdType": "SUBMISSION_ID"
+      |     },
+      |     {
+      |       "correlationId": "22bbf4e1-5f4c-4d2e-9c8b-1f4e6e8c9a12",
+      |       "correlationIdType": "SESSION_ID"
+      |     }
+      |  ],
       |  "submitter": "sa-reg",
       |  "decisionData": [
       |    {
@@ -57,9 +63,15 @@ trait OutcomeAuditV2 {
 
   val invalidOutcomeAuditingV2Json: JsValue = Json.parse(
     """{
-      |  "correlationData": {
-      |    "correlationId": "33df37a4-a535-41fe-8032-7ab718b45526"
-      |  },
+      |  "correlationData": [
+      |     {
+      |       "correlationId": "33df37a4-a535-41fe-8032-7ab718b45526",
+      |       "correlationIdType": "ACKNOWLEDGEMENT_ID"
+      |     },
+      |     {
+      |       "correlationId": "22df37a4-a535-41fe-8032-7ab718b45526"
+      |     }
+      |  ],
       |  "submitter": "sa-reg",
       |  "decisionData": [
       |    {


### PR DESCRIPTION
This pull request updates the structure of the `correlationData` field in the outcome auditing V2 test data and related tests. The main change is moving from a single object to an array of objects for `correlationData`, allowing for multiple correlation IDs and types to be included and validated in the tests.

**Test data structure changes:**

* Updated the `validOutcomeAuditingV2Json` and `invalidOutcomeAuditingV2Json` in `OutcomeAuditV2.scala` to represent `correlationData` as an array of objects, each containing a `correlationId` and `correlationIdType` (where applicable), instead of a single object. [[1]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL24-R33) [[2]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL60-R74)

**Test validation logic updates:**

* Modified the test in `OutcomeAuditingV2Spec.scala` to validate multiple entries in the `correlationData` array, checking both correlation IDs and types at the correct array indices.