### PR TITLE
CIR-2881 Update to `Accepted`

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
@@ -51,7 +51,7 @@ class OutcomeAuditingV2Spec extends BaseSpec with OutcomeAuditV2 with WireMockTr
                 s"&& @.detail.correlationData[1].correlationIdType == 'SESSION_ID'" +
                 s"&& @.detail.submitter == 'sa-reg'" +
                 s"&& @.detail.decisionData[0].businessEvent == 'SARegistrationSubmitted'" +
-                s"&& @.detail.decisionData[0].decision == 'ACCEPT'" +
+                s"&& @.detail.decisionData[0].decision == 'ACCEPTED'" +
                 s"&& @.detail.decisionData[0].evidence[0].decisionMethod == 'AUTOMATIC'" +
                 s"&& @.detail.decisionData[0].evidence[0].decisionSystem == 'sa-reg'" +
                 s"&& @.detail.decisionData[0].evidence[0].decisionTimestamp == '2025-07-09T08:14:13Z'" +

--- a/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
@@ -35,7 +35,7 @@ trait OutcomeAuditV2 {
       |  "decisionData": [
       |    {
       |      "businessEvent": "SARegistrationSubmitted",
-      |      "decision": "ACCEPT",
+      |      "decision": "ACCEPTED",
       |      "reasons": [
       |        "LOW_RISK_SCORE"
       |      ],
@@ -76,7 +76,7 @@ trait OutcomeAuditV2 {
       |  "decisionData": [
       |    {
       |      "businessEvent": "SARegistrationSubmitted",
-      |      "decision": "ACCEPT",
+      |      "decision": "ACCEPTED",
       |      "reasons": [
       |        "LOW_RISK_SCORE"
       |      ],


### PR DESCRIPTION
This pull request updates the terminology used for audit outcomes in the test data and related assertions to ensure consistency with the new standard. The main change is replacing the decision value from "ACCEPT" to "ACCEPTED" in both the test data and the corresponding test assertions.

**Test data and assertion updates:**

* Updated the `decision` field from `"ACCEPT"` to `"ACCEPTED"` in the `decisionData` sections of test data within `OutcomeAuditV2.scala` to match new outcome terminology. [[1]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL38-R38) [[2]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL79-R79)
* Modified the JSON path assertion in `OutcomeAuditingV2Spec.scala` to expect `"ACCEPTED"` instead of `"ACCEPT"` for the `decision` field, ensuring tests align with the updated standard.