### PR TITLE
CIR-2834 Adding caseNotes to API test

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,8 @@ object Dependencies {
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"         %% "api-test-runner"          % "0.10.0",
-    "org.wiremock"         % "wiremock"                 % "3.13.1",
-    "io.swagger.parser.v3" % "swagger-parser"           % "2.1.31",
+    "org.wiremock"         % "wiremock"                 % "3.13.2",
+    "io.swagger.parser.v3" % "swagger-parser"           % "2.1.40",
     "org.openapi4j"        % "openapi-schema-validator" % "1.0.7"
   ).map(_ % Test)
 }

--- a/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/V2/OutcomeAuditingV2Spec.scala
@@ -60,6 +60,7 @@ class OutcomeAuditingV2Spec extends BaseSpec with OutcomeAuditV2 with WireMockTr
                 s"&& @.detail.decisionData[0].evidence[0].attributes[0].attributeValue == '123456789'" +
                 s"&& @.detail.decisionData[0].evidence[0].attributes[1].attributeType == 'NINO'" +
                 s"&& @.detail.decisionData[0].evidence[0].attributes[1].attributeValue == '987654321'" +
+                s"&& @.detail.decisionData[0].caseNotes == 'test case notes for SA registration submission'" +
                 ")]"
             )
           )

--- a/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/testdata/OutcomeAuditV2.scala
@@ -56,7 +56,8 @@ trait OutcomeAuditV2 {
       |            }
       |          ]
       |        }
-      |      ]
+      |      ],
+      |      "caseNotes": "test case notes for SA registration submission"
       |    }
       |  ]
       |}""".stripMargin)
@@ -97,7 +98,8 @@ trait OutcomeAuditV2 {
       |            }
       |          ]
       |        }
-      |      ]
+      |      ],
+      |      "caseNotes": "test case notes for SA registration submission"
       |    }
       |  ]
       |}""".stripMargin) // Missing correlationIdType in correlationData


### PR DESCRIPTION
This pull request updates the outcome auditing V2 test data and related test assertions to include a new `caseNotes` field for SA registration submissions. The main focus is ensuring that the new field is present and correctly validated in both the test data and the test assertions.

**Test Data and Assertion Updates:**

* Added a `"caseNotes"` field with the value `"test case notes for SA registration submission"` to the test data JSON in `OutcomeAuditV2.scala` to reflect new requirements. [[1]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL59-R60) [[2]](diffhunk://#diff-8eb83bbb547f80ccf42aef3c3c3c581e48b99b4c4cbe0738c4795261704d28acL100-R102)
* Updated the test assertion in `OutcomeAuditingV2Spec.scala` to check for the presence and correct value of the new `caseNotes` field.